### PR TITLE
:new: Add regex for yes/no prompts

### DIFF
--- a/my-music
+++ b/my-music
@@ -2,6 +2,9 @@
 
 ########## VARIABLES ##########
 
+## Helpers
+yesReg="^(y|Y)(es)?$"
+
 ## Output
 bold=$(tput bold)
 clear=$(tput clear)
@@ -77,7 +80,7 @@ addRecord ()
 
 	echo -n "Did you listen? (y|n) "
 	read listened
-	if [ "$listened" == "y" ]; then
+	if [[ "$listened" =~ $yesReg ]]; then
 		listened=true
 	else
 		listened=false
@@ -85,7 +88,7 @@ addRecord ()
 
 	echo -n "Did you like? (y|n) "
 	read liked
-	if [ "$liked" == "y" ]; then
+	if [[ "$liked" =~ $yesReg ]]; then
 		liked=true
 	else
 		liked=false
@@ -93,7 +96,7 @@ addRecord ()
 
 	echo -n "Did you purchase? (y|n) "
 	read purchased
-	if [ "$purchased" == "y" ]; then
+	if [[ "$purchased" =~ $yesReg ]]; then
 		purchased=true
 	else
 		purchased=false
@@ -109,7 +112,8 @@ addRecord ()
 	echo "purchased: $purchased"
 	echo -n "ok? (y|n) "
 	read confirm
-	if [ "$confirm" != "y" ]; then
+	if ! [[ "$confirm" =~ $yesReg ]]; then
+		echo "Not confirmed. Returning"
 		return
 	fi
 
@@ -156,7 +160,7 @@ listenToRecord ()
 
 	echo -n "Did you like? (y|n) "
 	read liked
-	if [ "$liked" == "y" ]; then
+	if [[ "$liked" =~ $yesReg ]]; then
 		liked=true
 	else
 		liked=false
@@ -164,7 +168,7 @@ listenToRecord ()
 
 	echo -n "Did you purchase? (y|n) "
 	read purchased
-	if [ "$purchased" == "y" ]; then
+	if [[ "$purchased" =~ $yesReg ]]; then
 		purchased=true
 	else
 		purchased=false


### PR DESCRIPTION
## Description
- add helper variable `yesReg="^(y|Y)(es)?$"` to program scope
  + matches `y`, `Y`, `yes`, `Yes`
- update existing yes/no prompts
  + change from `[ ]` to `[[ ]]` in order to use `$yesReg` without strings
  + change from `=` to `=~`
  + replace `"y"` with `$yesReg`
- in procedure `addRecord` add extra output if record not confirmed in order to make it obvious that no record was inserted
  

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

